### PR TITLE
Jehwan/1 1주차 리펙토링

### DIFF
--- a/jehwan/week-1/src/point/point.dto.ts
+++ b/jehwan/week-1/src/point/point.dto.ts
@@ -1,6 +1,7 @@
-import { IsInt } from 'class-validator'
+import { IsInt, Min } from 'class-validator'
 
 export class PointBody {
+  @Min(0)
   @IsInt()
   amount: number
 }

--- a/jehwan/week-1/src/point/point.module.ts
+++ b/jehwan/week-1/src/point/point.module.ts
@@ -2,10 +2,20 @@ import { Module } from '@nestjs/common'
 import { PointController } from './point.controller'
 import { DatabaseModule } from '../database/database.module'
 import { PointService } from './point.service'
+import { PointHistoryRepository, UserPointRepository } from './point.repository'
+import { PointHistoryTable } from '../database/pointhistory.table'
+import { UserPointTable } from '../database/userpoint.table'
 
 @Module({
   imports: [DatabaseModule],
   controllers: [PointController],
-  providers: [PointService],
+  providers: [
+    PointService,
+    {
+      provide: PointHistoryRepository,
+      useClass: PointHistoryTable,
+    },
+    { provide: UserPointRepository, useClass: UserPointTable },
+  ],
 })
 export class PointModule {}

--- a/jehwan/week-1/src/point/point.repository.ts
+++ b/jehwan/week-1/src/point/point.repository.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common'
+import { PointHistory, TransactionType, UserPoint } from './point.model'
+
+@Injectable()
+export abstract class PointHistoryRepository {
+  abstract selectAllByUserId(userId: number): Promise<PointHistory[]>
+
+  abstract insert(
+    userId: number,
+    amount: number,
+    transactionType: TransactionType,
+    updateMillis: number,
+  ): Promise<PointHistory>
+}
+
+@Injectable()
+export abstract class UserPointRepository {
+  abstract selectById(userId: number): Promise<UserPoint>
+
+  abstract insertOrUpdate(userId: number, amount: number): Promise<UserPoint>
+}

--- a/jehwan/week-1/src/point/point.service.spec.ts
+++ b/jehwan/week-1/src/point/point.service.spec.ts
@@ -40,6 +40,11 @@ describe('PointService', () => {
         expect(pointAfterCharge.point).toBe(accumulates[parseInt(i) + 1])
       }
     })
+    it('Fail to charge if the point value is negative', async () => {
+      const userId = 1
+      const amount = -1 * Math.floor(1000 * Math.random())
+      await expect(pointService.charge(userId, amount)).rejects.toThrow(Error)
+    })
   })
 
   describe('PointService.use()', () => {

--- a/jehwan/week-1/src/point/point.service.spec.ts
+++ b/jehwan/week-1/src/point/point.service.spec.ts
@@ -3,13 +3,24 @@ import { PointService } from './point.service'
 import { UserPointTable } from '../database/userpoint.table'
 import { TransactionType } from './point.model'
 import { PointHistoryTable } from '../database/pointhistory.table'
+import { PointHistoryRepository, UserPointRepository } from './point.repository'
 
 describe('PointService', () => {
   let pointService: PointService
 
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
-      providers: [PointService, UserPointTable, PointHistoryTable],
+      providers: [
+        PointService,
+        {
+          provide: PointHistoryRepository,
+          useClass: PointHistoryTable,
+        },
+        {
+          provide: UserPointRepository,
+          useClass: UserPointTable,
+        },
+      ],
     }).compile()
 
     pointService = app.get<PointService>(PointService)

--- a/jehwan/week-1/src/point/point.service.ts
+++ b/jehwan/week-1/src/point/point.service.ts
@@ -19,6 +19,10 @@ export class PointService {
    * @returns balance after charge
    */
   async charge(userId: number, amount: number): Promise<UserPoint> {
+    if (amount < 0) {
+      throw Error('The amount must be greater than and equal to 0')
+    }
+
     // critical section
     await this.waitWriteLock()
     this.writeLock = true

--- a/jehwan/week-1/test/app.e2e-spec.ts
+++ b/jehwan/week-1/test/app.e2e-spec.ts
@@ -111,6 +111,14 @@ describe('AppController (e2e)', () => {
       // The order of calling is not important.
       expect(getMinPoint(fulfilled)).toBe(8500)
     })
+    it('Use the negative point', async () => {
+      await request(app.getHttpServer())
+        .patch('/point/1/charge')
+        .send({
+          amount: -1000,
+        })
+        .expect(400)
+    })
     it('Return BadRequest when if the balance is insufficient', async () => {
       request(app.getHttpServer())
         .patch('/point/1/use')

--- a/jehwan/week-1/test/app.e2e-spec.ts
+++ b/jehwan/week-1/test/app.e2e-spec.ts
@@ -54,8 +54,7 @@ describe('AppController (e2e)', () => {
 
       // If sorted by amount, the largest result should be 100000.
       // The order of calling is not important.
-      fulfilled.sort((a, b) => a.value.body.point - b.value.body.point)
-      expect(fulfilled.map(r => r.value.body.point).at(-1)).toBe(100000)
+      expect(getMaxPoint(fulfilled)).toBe(100000)
     })
     it('Charge the negative point', async () => {
       await request(app.getHttpServer())
@@ -110,8 +109,7 @@ describe('AppController (e2e)', () => {
 
       // If sorted by amount, the smallest result should be 8500.
       // The order of calling is not important.
-      fulfilled.sort((a, b) => a.value.body.point - b.value.body.point)
-      expect(fulfilled.map(r => r.value.body.point).at(0)).toBe(8500)
+      expect(getMinPoint(fulfilled)).toBe(8500)
     })
     it('Return BadRequest when if the balance is insufficient', async () => {
       request(app.getHttpServer())
@@ -190,4 +188,12 @@ function asAllFulfilled(
   requests: PromiseSettledResult<supertest.Response>[],
 ): PromiseFulfilledResult<supertest.Response>[] {
   return requests as PromiseFulfilledResult<supertest.Response>[]
+}
+
+function getMaxPoint(fulfilled: PromiseFulfilledResult<supertest.Response>[]) {
+  return Math.max(...fulfilled.map(r => r.value.body.point))
+}
+
+function getMinPoint(fulfilled: PromiseFulfilledResult<supertest.Response>[]) {
+  return Math.min(...fulfilled.map(r => r.value.body.point))
 }

--- a/jehwan/week-1/test/app.e2e-spec.ts
+++ b/jehwan/week-1/test/app.e2e-spec.ts
@@ -52,6 +52,14 @@ describe('AppController (e2e)', () => {
       requests.sort((a, b) => a.body.point - b.body.point)
       expect(requests.map(r => r.body.point).at(-1)).toBe(100000)
     })
+    it('Charge the negative point', async () => {
+      await request(app.getHttpServer())
+        .patch('/point/1/charge')
+        .send({
+          amount: -1000,
+        })
+        .expect(400)
+    })
   })
   describe('PATCH /point/{id}/use', () => {
     beforeEach(async () => {


### PR DESCRIPTION
### Table 단위 Lock -> User 단위 Lock

```ts
export class PointService {
  private writeLockTable: Record<number, boolean> = {}

  /**
   *
   * busy waiting
   * @param userId user's ID
   * @param interval checking interval (default 10ms)
   */
  private waitWriteLock(userId: number, interval?: number) {
    return new Promise(resolve => {
      const checkLock = () => {
        if (this.writeLockTable[userId]) {
          setTimeout(checkLock, interval ?? 10)
        } else {
          resolve(true)
        }
      }
      checkLock()
    })
  }
}
```

Map 자료 구조를 이용하여, 기존 Table 단위 Lock 과 User 단위 Lock 으로 리팩토링 함.

### 동시성 테스트

```ts
    it('Charge and Use user points concurrently - outcome depends on which request is handled first', async () => {
  // Send charge and use requests concurrently
  const requests = [
    request(app.getHttpServer())
      .patch('/point/1/charge')
      .send({ amount: 10000 }),
    request(app.getHttpServer())
      .patch('/point/1/use')
      .send({ amount: 30000 }),
  ]

  // Handled first request
  const firstResponse = await Promise.race(requests)

  // Both would have been processed and completed here
  const chargeResponse = await requests[0]
  const useResponse = await requests[1]

  // Check remaining points.
  const finalPointResponse = await request(app.getHttpServer()).get(
    '/point/1',
  )

  /**
   * If the charge request is handled first, the balance will be 0.
   * If the use request is handled first, the balance will be 30000.
   */
  switch (firstResponse) {
    case chargeResponse:
      expect(finalPointResponse.body.point).toBe(0)
      break
    case useResponse:
      expect(finalPointResponse.body.point).toBe(30000)
      break
  }
})
it('Charge and Use user points concurrently - outcome depends on which request has the error (Network)', async () => {
  // Mock functions randomly that always throw Error
  const mockChargeRequest = randomlyFails((id, amount) =>
    request(app.getHttpServer())
      .patch(`/point/${id}/charge`)
      .send({ amount }),
  )
  const mockUseRequest = randomlyFails((id, amount) =>
    request(app.getHttpServer()).patch(`/point/${id}/use`).send({ amount }),
  )

  // Send charge and use requests concurrently
  const requests = [
    mockUseRequest('1', 10000),
    mockChargeRequest('1', 10000),
  ]

  const [useResponse, chargeResponse] = await Promise.allSettled(requests)

  // Check remaining points.
  const finalPointResponse = await request(app.getHttpServer()).get(
    '/point/1',
  )

  /**
   * Check outcome depends on which request has the error (Network)
   */
  if (
    useResponse.status === 'rejected' &&
    chargeResponse.status === 'rejected'
  ) {
    expect(finalPointResponse.body.point).toBe(20000)
  }

  if (
    useResponse.status === 'rejected' &&
    chargeResponse.status === 'fulfilled'
  ) {
    expect(finalPointResponse.body.point).toBe(30000)
  }

  if (
    useResponse.status === 'fulfilled' &&
    chargeResponse.status === 'rejected'
  ) {
    expect(finalPointResponse.body.point).toBe(10000)
  }

  if (
    useResponse.status === 'fulfilled' &&
    chargeResponse.status === 'fulfilled'
  ) {
    expect(finalPointResponse.body.point).toBe(20000)
  }
})
```

동시에 요청을 보내고, 요청이 처리 되는 순서에 따라 기대 값을 미리 준비하여 테스트 함.
